### PR TITLE
fix 2-2-3-3_address.sol

### DIFF
--- a/2/2/2-2-3-3_address.sol
+++ b/2/2/2-2-3-3_address.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.24 <0.6.0;
+pragma solidity ^0.4.24;
 
 contract Address {
 


### PR DESCRIPTION
バージョンを0.4.xに制限
これによりaddress payableに関するエラーはなくなる