### PR TITLE
fix mapping keyword spaces

### DIFF
--- a/2/3/2-3-3-3_mapping_example
+++ b/2/3/2-3-3-3_mapping_example
@@ -1,1 +1,1 @@
-mapping (uint => address) public zombieToOwner;
+mapping(uint => address) public zombieToOwner;

--- a/6/4/6-4-3-1_Room.sol
+++ b/6/4/6-4-3-1_Room.sol
@@ -7,7 +7,7 @@ import "openzeppelin-solidity/contracts/lifecycle/Destructible.sol";
 contract Room is Destructible, Pausable {
 
     // ②
-    mapping (uint256 => bool) public rewardSent;
+    mapping(uint256 => bool) public rewardSent;
 
     // ③
     event Deposited(

--- a/6/4/6-4-3-4_Room.sol
+++ b/6/4/6-4-3-4_Room.sol
@@ -7,7 +7,7 @@ import "./Activatable.sol"; // ①
 // ②
 contract Room is Destructible, Pausable, Activatable {
 
-    mapping (uint256 => bool) public rewardSent;
+    mapping(uint256 => bool) public rewardSent;
 
     event Deposited(
         address indexed _depositor,


### PR DESCRIPTION
mappingキーワードの直後にスペースが有るのと無いので混ざっていたため、
無いほうに統一